### PR TITLE
Use wall and werror

### DIFF
--- a/haskell-sqlite.cabal
+++ b/haskell-sqlite.cabal
@@ -25,7 +25,7 @@ library
 executable haskell-sqlite-exe
   hs-source-dirs:      app
   main-is:             Main.hs
-  ghc-options:         -threaded -rtsopts -with-rtsopts=-N
+  ghc-options:         -threaded -rtsopts -with-rtsopts=-N -Wall -Werror
   build-depends:       base
                      , haskell-sqlite
   default-language:    Haskell2010

--- a/src/Interpreter.hs
+++ b/src/Interpreter.hs
@@ -7,8 +7,6 @@ module Interpreter
     )
 where
 
-import           Control.Monad (forever)
-import           Data.Monoid   ((<>))
 import           Data.Text
 import           Syntax
 
@@ -27,6 +25,6 @@ console = do
   let output = interpret $ pack line
   case output of
     Exit     -> putStrLn "bye !"
-    Sql stmt -> do
+    Sql _ -> do
       putStrLn "Parsed o7"
       console

--- a/src/Syntax.hs
+++ b/src/Syntax.hs
@@ -6,12 +6,8 @@ module Syntax
     )
 where
 
-import           Control.Monad
-import           Data.Maybe
-import           Data.Monoid
 import           Data.Text
 import           Text.Parsec
-import           Text.Parsec.Char
 
 newtype Select = Select Text
                  deriving (Eq, Show)
@@ -41,29 +37,30 @@ sqlParser sql = mapToSqlStatement sql selectPart fromPart wherePart
 selectParser :: Text -> Maybe Select
 selectParser statement = do
    case parse parser "<STDIN>" (unpack statement) of
-      Left err     -> Nothing
+      Left _       -> Nothing
       Right parsed -> Just (Select $ strip $ pack parsed)
    where
-    parser = string "SELECT" *> space >> untilFrom
+    parser = string "SELECT" *> space *> untilFrom
 
 fromParser :: Text -> Maybe From
 fromParser statement = do
     case parse parser "<STDIN>" (unpack statement) of
-        Left err     -> Nothing
+        Left _       -> Nothing
         Right parsed -> Just (From $ strip $ pack parsed)
     where
-     parser = untilFrom *> many1 space >> untilWhere
+     parser = untilFrom *> many1 space *> untilWhere
 
 whereParser :: Text -> Maybe Where
 whereParser statement = do
     case parse parser "<STDIN>" (unpack statement) of
-        Left err     -> Nothing
+        Left _       -> Nothing
         Right parsed -> Just (Where $ pack parsed)
     where
-     parser = untilWhere *> space >> many anyChar
+     parser = untilWhere *> space *> many anyChar
 
 untilKeyword :: String -> Parsec String () String
 untilKeyword keyword = manyTill anyChar (try (string keyword))
 
+untilWhere, untilFrom :: Parsec String () String
 untilFrom = untilKeyword "FROM"
 untilWhere = untilKeyword "WHERE"


### PR DESCRIPTION
This PR helps the compiler (and Intero if you use it !) catch more warnings for you. This will give you a more idiomatic style (and force you to type top-level expression, which is good training). The PR also contains the fix for current breaking warnings (maybe you'll find -Werror is a bit too much though - at least for a toy project).

You might also want to install hlint (`stack install hlint` - normally, a global install, outside of your project directory, should work and enable it in all your project). It will catch some "gotcha" for you and it interacts nicely with emacs. However (couldn't see if they fixed this), intero tends to block it on emacs (well, on spacemacs actually, I don't use raw emacs). If you're using spacemacs, you might want to add these lines to your dotemacs file:

```
dotspacemacs/user-config ()
  (with-eval-after-load 'intero
    (flycheck-add-next-checker 'intero '(warning . haskell-hlint)))
```